### PR TITLE
Fix a potential buffer size misaligning issue in TMA description of partition attention

### DIFF
--- a/megakernels/demos/latency/scheduler.py
+++ b/megakernels/demos/latency/scheduler.py
@@ -48,7 +48,10 @@ def make_globals(
 
     stacked_params = model.stacked_params
 
-    max_attn_partitions = get_sm_count(device)
+    def align_sm_to_partition_cacheline(x: int) -> int:
+        return int(math.ceil(x / 16) * 16)
+
+    max_attn_partitions = align_sm_to_partition_cacheline(get_sm_count(device))
 
     barriers = torch.zeros(
         [
@@ -59,6 +62,7 @@ def make_globals(
         dtype=torch.int32,
         device=device,
     )
+
 
     return Globals(
         # model params


### PR DESCRIPTION
The TMA descriptor for attn_lse_intermediates is initialized based on the original number of SMs in the hardware during make_globals (in latency/scheduler.py). However, its actual allocated size is later rounded up to a multiple of 16 based on the number of SMs (in demos/low-latency-llama/attention_reduction.cu). This discrepancy leads to a failure when creating the TMA descriptor.