### PR TITLE
fix(demos): specify gencode sm_90a

### DIFF
--- a/demos/low-latency-llama/Makefile
+++ b/demos/low-latency-llama/Makefile
@@ -22,7 +22,7 @@ NVCCFLAGS+= -DKITTENS_4090 -arch=sm_89
 else ifeq ($(GPU),A100)
 NVCCFLAGS+= -DKITTENS_A100 -arch=sm_80
 else ifeq ($(GPU),H100)
-NVCCFLAGS+= -DKITTENS_HOPPER -arch=sm_90a
+NVCCFLAGS+= -DKITTENS_HOPPER -gencode arch=compute_90a,code=sm_90a
 else
 NVCCFLAGS+= -DKITTENS_HOPPER -DKITTENS_BLACKWELL -arch=sm_100a
 endif


### PR DESCRIPTION
## Description

On my nvcc12.9+H800,  `NVCCFLAGS+= -DKITTENS_HOPPER -arch=sm_90a` would also generate `sm_90` ptx code. 

Here is the minimal reproducation:

<img width="1524" height="344" alt="image" src="https://github.com/user-attachments/assets/9270cd82-0049-42d6-ab44-d645f9d31b83" />

Unfortunately, `setmaxnreg.inc`  in `include/ops/group/group.cuh` only support  `sm_90a` (see [cuda ptx doc](https://docs.nvidia.com/cuda/parallel-thread-execution/#ptx-isa-version-9-2))

Finally it crashed:
<img width="1476" height="210" alt="image" src="https://github.com/user-attachments/assets/5f5a7e25-c92d-417b-8033-978870830e35" />

## Fix
Specify arch and gencode as `sm_90a`